### PR TITLE
fix pass-by-reference error

### DIFF
--- a/public/class-wp-hide-post-public.php
+++ b/public/class-wp-hide-post-public.php
@@ -315,7 +315,7 @@ class wp_hide_post_Public
      * @param $join
      * @return unknown_type
      */
-    public function query_posts_join($join, &$wp_query)
+    public function query_posts_join($join, $wp_query)
     {
 
         if (isset($wp_query->query['wphp_inside_recent_post_sidebar']))


### PR DESCRIPTION
query_posts_join takes its 2nd param by reference when it should be taking it by value. This fixes a wordpress warning that is thrown.