### PR TITLE
No need to enqueue an empty script!

### DIFF
--- a/public/class-wp-hide-post-public.php
+++ b/public/class-wp-hide-post-public.php
@@ -110,7 +110,7 @@ if (!class_exists('wp_hide_post_Public'))
              * class.
              */
 
-            wp_enqueue_script($this->wp_hide_post, plugin_dir_url(__FILE__) . 'js/wp-hide-post-public.js', array('jquery'), $this->version, false);
+            // wp_enqueue_script($this->wp_hide_post, plugin_dir_url(__FILE__) . 'js/wp-hide-post-public.js', array('jquery'), $this->version, false);
 
         }
         private function exclude_low_profile_items($item_type, $posts)


### PR DESCRIPTION
This PR addresses issue #5 by commenting out the enqueueing of the public JS script. At this time the script does not have any code so we shouldn't need to include it.

This will reduce the amount of files being added by the plugin to help ensure sites using it don't send unnecessary resources to the end user's browser.