### PR TITLE
Fix class-wp-hide-post-public.php

### DIFF
--- a/public/class-wp-hide-post-public.php
+++ b/public/class-wp-hide-post-public.php
@@ -345,7 +345,7 @@ if (!class_exists('wp_hide_post_Public'))
          * @since    1.2.2
          */
 
-        public function query_posts_join($join, &$wp_query)
+        public function query_posts_join($join, $wp_query)
         {
             if (isset($wp_query->query['wphp_inside_recent_post_sidebar']))
             {


### PR DESCRIPTION
Compatibility issue with PHP 7.1 to avoid:
PHP Warning:  Parameter 2 to wp_hide_post_Public::query_posts_join() expected to be a reference, value given in wp-includes/class-wp-hook.php