### PR TITLE
Load PayPal donate button image via HTTPS

### DIFF
--- a/admin/class-wp-hide-post-admin.php
+++ b/admin/class-wp-hide-post-admin.php
@@ -1160,7 +1160,7 @@ $current_v = isset($_GET['wphp_hidden_on']) ? $_GET['wphp_hidden_on'] : array();
 </div><div style="clear:both">' . $price ? '' : '
 <div style="text-align:center">
     <a href="http://scriptburn.com/wp-hide-post">
-        <img src="http://www.paypalobjects.com/webstatic/en_US/btn/btn_donate_pp_142x27.png"/>
+        <img src="https://www.paypalobjects.com/webstatic/en_US/btn/btn_donate_pp_142x27.png"/>
     </a>
 </div>
 <div style="clear:both">


### PR DESCRIPTION
The PayPal donate button image is shown in the admin section when editing a post. It is currently loaded using HTTP which results in a non-green padlock in browsers when the WordPress site uses HTTPS. Simply changing HTTP to HTTPS fixes this problem.