### PR TITLE
Fix issue of filters not running when using wp ajax

### DIFF
--- a/includes/class-wp-hide-post.php
+++ b/includes/class-wp-hide-post.php
@@ -319,7 +319,7 @@ if (!class_exists('wp_hide_post'))
          */
         private function define_public_hooks()
         {
-            if (is_admin())
+            if (is_admin() && ! wp_doing_ajax())
             {
                 return;
             }

--- a/includes/helpers.php
+++ b/includes/helpers.php
@@ -155,7 +155,7 @@ if (!function_exists('wphp_is_applicable'))
             //p_n(__LINE__);
             $ret = 1;
         }
-        elseif (is_admin() || is_singular())
+        elseif ((is_admin() && ! wp_doing_ajax()) || is_singular())
         {
 
             if (@is_front_page())

--- a/public/class-wp-hide-post-public.php
+++ b/public/class-wp-hide-post-public.php
@@ -411,7 +411,7 @@ if (!class_exists('wp_hide_post_Public'))
         {
 
             // Only filter the main query on the front-end
-            if (is_admin() || !$query->is_main_query())
+            if ((is_admin() && ! wp_doing_ajax()) || !$query->is_main_query())
             {
                 return;
             }


### PR DESCRIPTION
I found that your filters were not running when I was doing a load more using wp_ajax. This was because there were cases where you were checking for ```is_admin()``` which will also be true in the case of wp_ajax. To fix this, you need to also check for ```! wp_doing_ajax()``` so that all public ajax calls will also use the filter.